### PR TITLE
Fix lint config and sanitize download filenames

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,15 +1,11 @@
-// eslint.config.js (ES Module version)
-export default {
-  root: true,
-  env: {
-    browser: true,
-    es2021: true,
-    greasemonkey: true
-  },
+import js from "@eslint/js";
+import globals from "globals";
+
+export default [
+  js.configs.recommended,
   {
-    ...js.configs.recommended,
+    files: ["**/*.js"],
     languageOptions: {
-      ...js.configs.recommended.languageOptions,
       ecmaVersion: "latest",
       sourceType: "module",
       globals: {
@@ -27,8 +23,8 @@ export default {
         tippy: "readonly",
         sha256: "readonly",
         saveAs: "readonly",
-        m3u8Parser: "readonly",
-      },
+        m3u8Parser: "readonly"
+      }
     },
     rules: {
       "no-unused-vars": ["warn"],
@@ -38,7 +34,7 @@ export default {
       "quotes": "off",
       "eqeqeq": ["error", "always"],
       "curly": ["warn", "multi-line"],
-      "no-empty-function": ["warn"],
-    },
-  },
+      "no-empty-function": ["warn"]
+    }
+  }
 ];


### PR DESCRIPTION
## Summary
- replace the broken ESLint flat config with a valid module setup and shared globals
- sanitize generated download paths with a helper to avoid control-character regex use and filename issues
- refactor download mapping to remove async promise executors while preserving progress updates

## Testing
- `npm exec eslint codex.user.js`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e32c2cc20832e95bed99400e8b938)